### PR TITLE
bugfix(font): Remove font-face cache

### DIFF
--- a/internal/fonts/fonts.go
+++ b/internal/fonts/fonts.go
@@ -63,21 +63,7 @@ func GetFont(fd FaceDescription) (*opentype.Font, error) {
 	return currentFace.font, nil
 }
 
-// Little dumb way to cache face for GetFontFace
-var prevFaceCache = struct {
-	fd   FaceDescription
-	face font.Face
-	mx   sync.Mutex
-}{}
-
 func GetFontFace(fd FaceDescription) (font.Face, error) {
-	prevFaceCache.mx.Lock()
-	defer prevFaceCache.mx.Unlock()
-
-	if prevFaceCache.fd == fd {
-		return prevFaceCache.face, nil
-	}
-
 	f, err := GetFont(fd)
 	if err != nil {
 		return nil, err
@@ -88,9 +74,6 @@ func GetFontFace(fd FaceDescription) (font.Face, error) {
 		DPI:     72,
 		Hinting: font.HintingFull,
 	})
-
-	prevFaceCache.face = face
-	prevFaceCache.fd = fd
 
 	return face, nil
 }


### PR DESCRIPTION
Font-face cache produces data-races
> A Face is not safe for concurrent use by multiple goroutines, as its methods may re-use implementation-specific caches and mask image buffers